### PR TITLE
chore: build merged static lib in CI

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2025 Siemens
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: lib
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  build_static_lib:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcmocka-dev meson ninja-build build-essential libssl-dev cmake pkg-config git llvm
+          cargo install armerge
+      - name: Checkout gta-api-core
+        uses: actions/checkout@v4
+        with:
+          repository: 'generic-trust-anchor-api/gta-api-core'
+          ref: 'main'
+      - name: Build and install gta-api-core
+        run: |
+          meson setup build
+          sudo ninja -C build install
+      - name: Checkout gta-api-sw-provider
+        uses: actions/checkout@v4
+      - name: Build gta-api-sw-provider
+        run: |
+          meson setup build
+          sudo ninja -C build
+      - name: Generate merged static lib
+        run: |
+          armerge --keep-symbols 'gta_sw_provider_init' --output build/libgta_sw_provider_merged.a build/src/libgta_sw_provider.a build/subprojects/openssl-3.0.8/libcrypto.a
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libgta_sw_provider_merged.a
+          path: build/libgta_sw_provider_merged.a
+


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->

To use and test the OpenSSL provider, a merged static library of the SW provider is needed. This PR builds the merged static lib on push events on the main branch and uploads it as artifact.

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [ ] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
