### PR TITLE
feat: add support for TPM2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,21 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libcmocka-dev meson ninja-build build-essential libssl-dev cmake pkg-config git valgrind
+          sudo apt-get update && sudo apt-get install -y libcmocka-dev meson ninja-build build-essential libssl-dev cmake pkg-config git valgrind libtss2-dev tpm2-tools
+      - name: Download and verify TPM Simulator
+        run: |
+          wget -O ibmtpm1682.tar.gz https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1682.tar.gz/download
+          echo "3cb642f871a17b23d50b046e5f95f449c2287415fc1e7aeb4bdbb8920dbcb38f  ibmtpm1682.tar.gz" | sha256sum -c -
+      - name: Install TPM Simulator
+        run: |
+          mkdir tpm_simulator
+          cd tpm_simulator
+          tar -xf ../ibmtpm1682.tar.gz
+          cd src
+          make
+          ./tpm_server &
+          export TPM2TOOLS_TCTI="mssim:host=127.0.0.1,port=2321"
+          tpm2_startup -c
       - name: Checkout liboqs
         uses: actions/checkout@v4
         with:
@@ -55,6 +69,16 @@ jobs:
       - name: Valgrind w/ PQC
         run: |
           ninja -C build gta_provider_memcheck
+      - name: Build gta-api-sw-provider w/ TPM2
+        run: |
+          meson setup build --reconfigure --werror -Denable-tpm2-backend=true -Dtcti-module='mssim' -Dtcti-conf='host=127.0.0.1,port=2321'
+          ninja -C build
+      - name: Test gta-api-sw-provider w/ TPM2
+        run: |
+          ninja -C build test
+#      - name: Valgrind w/ TPM2
+#        run: |
+#          ninja -C build gta_provider_memcheck
 
   style-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,7 +18,21 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libcmocka-dev meson ninja-build build-essential libssl-dev cmake pkg-config git gcovr lcov
+          sudo apt-get update && sudo apt-get install -y libcmocka-dev meson ninja-build build-essential libssl-dev cmake pkg-config git gcovr lcov libtss2-dev tpm2-tools
+      - name: Download and verify TPM Simulator
+        run: |
+          wget -O ibmtpm1682.tar.gz https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm1682.tar.gz/download
+          echo "3cb642f871a17b23d50b046e5f95f449c2287415fc1e7aeb4bdbb8920dbcb38f  ibmtpm1682.tar.gz" | sha256sum -c -
+      - name: Install TPM Simulator
+        run: |
+          mkdir tpm_simulator
+          cd tpm_simulator
+          tar -xf ../ibmtpm1682.tar.gz
+          cd src
+          make
+          ./tpm_server &
+          export TPM2TOOLS_TCTI="mssim:host=127.0.0.1,port=2321"
+          tpm2_startup -c
       - name: Checkout gta-api-core
         uses: actions/checkout@v4
         with:
@@ -36,9 +50,14 @@ jobs:
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
       - name: Run Build Wrapper
         run: |
-          meson setup build
+          meson setup build -Denable-tpm2-backend=true -Dtcti-module='mssim' -Dtcti-conf='host=127.0.0.1,port=2321'
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ninja -C build
-      - name: Create coverage report
+      - name: Create coverage report w/ TPM2
+        run: |
+          meson setup coverage_tpm -Denable-tpm2-backend=true -Dtcti-module='mssim' -Dtcti-conf='host=127.0.0.1,port=2321' -Db_coverage=true
+          ninja -C coverage_tpm test
+          ninja -C coverage_tpm coverage-sonarqube
+      - name: Create coverage report w/o TPM2
         run: |
           meson setup coverage -Db_coverage=true
           ninja -C coverage test
@@ -50,4 +69,4 @@ jobs:
         with:
           args: >
             --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
-            --define sonar.coverageReportPaths=coverage/meson-logs/sonarqube.xml
+            --define sonar.coverageReportPaths=coverage_tpm/meson-logs/sonarqube.xml,coverage/meson-logs/sonarqube.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright 2024-2025 Siemens
+SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -15,15 +15,23 @@ intended for productive use.
 
 Nevertheless, the software provider is prepared to achieve a minimal security
 level by protecting its persisted state (i.e., device state, personalities,
-further metadata) with a hardware unique key. The 32 Byte platform specific
-hardware unique key needs to be provided to the function `get_hw_unique_key_32`
-in the file [key_management.c](src/key_management.c).
+further metadata) with a hardware unique key and a monotonic counter. The 32
+Byte platform specific hardware unique key needs to be provided to the function
+`get_hw_unique_key_32` in the file [key_management.c](src/key_management.c). The
+same file contains hooks to operate a monotonic counter.
 
 The GTA API software provider allows to develop an application which is based on
 the GTA API interfaces without having a secure element. The GTA API software
 provider can then be enhanced (e.g., by providing a hardware unique key) or
 replaced by another provider supporting some hardware secure element at a later
 stage.
+
+The software provider can be configured to use the TPM 2.0 to protect
+its persistent state. It then derives a hardware unique key from the Endorsement
+hierarchy of the TPM and initializes and uses an NV index as monotonic counter.
+See [Meson Options File](#meson-options-file) for the available configuration
+options.
+
 
 The cryptographic functions are computed using the
 [OpenSSL](https://openssl-library.org/) library as 3rd party cryptographic
@@ -65,6 +73,16 @@ The build and test of the GTA API SW provider depend on the GTA API Core and
 it's dependencies. To build the provider with Post-Quantum crypto algorithms,
 [liboqs](https://github.com/open-quantum-safe/liboqs) needs to be installed on
 the system.
+
+When the TPM 2.0 backend is enabled (`enable-tpm2-backend=true`, and optionally
+`enable-tpm2-monotonic-counter=true`), the provider links against the
+[tpm2-tss](https://github.com/tcg-tpm2-software/tpm2-tss) libraries. The
+Enhanced System API (ESAPI, `tss2-esys`) and the TCTI loader
+(`tss2-tctildr`) need to be installed on the system, including their
+development headers (`tss2/tss2_esys.h`, `tss2/tss2_tctildr.h`). On
+Debian/Ubuntu these are provided by the `libtss2-dev` package. At runtime a TPM
+2.0 must be reachable through the configured TCTI module (see the `tcti-module`
+option): `tcti-device` accesses a physical/firmware TPM (e.g., `/dev/tpm0`).
 
 ## Local build
 * In the project root, initialize build system and build directory (like ./configure for automake):
@@ -169,6 +187,16 @@ Currently the following options are available:
 | enable-post-quantum-crypto | boolean : { true, false } | This switch enables post quantum crypto algorithms. |
 | enable-test-log | boolean : { true, false } | This switch enables log messages for the provider tests. |
 | build-examples | boolean : { true, false } | This switch enables the build of examples. |
+
+The following options are available to enable the use of a TPM 2.0 to protect
+the persistent state of the software provider:
+
+| Option Name | Possible values | Description |
+| :---------- | :-------------- | :---------- |
+| enable-tpm2-backend | boolean : { true, false } | This switch enables the use of a TPM2 to protect the persisted state |
+| tcti-module | combo : { 'device', 'mssim' } | Select TCTI module in case TPM2 is enabled |
+| tcti-conf | string | Optional TCTI connection configuration appended to the selected module, e.g. `host=127.0.0.1,port=2321` for `mssim`. Leave empty to use the module's default. |
+| enable-tpm2-monotonic-counter | boolean' { true, false } |  This switch enables the use of a TPM2 based monotonic counter to enhance the protection of the persisted state. This option depends on enable-tpm2-backend=true |
 
 
 ## Coverage Report

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project('Generic Trust Anchor API SW Provider',
         'buildtype=plain',
     ],
     license: 'Apache-2.0',
-    meson_version: '>=0.56.0',
+    meson_version: '>=0.57.0',
     version: '0.2'
 )
 
@@ -29,8 +29,6 @@ add_project_arguments(
 
 # Get custom build options from meson_options.txt
 build_type = get_option('build')
-enable_tpm2_backend = get_option('enable-tpm2-backend')
-tcti_module = get_option('tcti-module')
 build_dep = get_option('build-dependencies')
 disable_deprecated = get_option('disable-deprecated-warnings')
 enable_pqc = get_option('enable-post-quantum-crypto')
@@ -96,7 +94,17 @@ if enable_tpm2_backend
       ),
       language: 'c'
    )
+   if enable_tpm2_monotonic_counter
+      add_project_arguments(
+         c_compiler.get_supported_arguments(
+            '-DENABLE_TPM2_MONOTONIC_COUNTER',
+         ),
+         language: 'c'
+      )
+   endif
 endif
+
+
 
 if enable_test_log
    add_project_arguments(

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024 Siemens
+# SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -29,11 +29,18 @@ add_project_arguments(
 
 # Get custom build options from meson_options.txt
 build_type = get_option('build')
+enable_tpm2_backend = get_option('enable-tpm2-backend')
+tcti_module = get_option('tcti-module')
 build_dep = get_option('build-dependencies')
 disable_deprecated = get_option('disable-deprecated-warnings')
 enable_pqc = get_option('enable-post-quantum-crypto')
 enable_test_log = get_option('enable-test-log')
 build_examples = get_option('build-examples')
+
+enable_tpm2_backend = get_option('enable-tpm2-backend')
+tcti_module = get_option('tcti-module')
+tcti_conf = get_option('tcti-conf')
+enable_tpm2_monotonic_counter = get_option('enable-tpm2-monotonic-counter')
 
 # TODO consider to use more generic override_options for build targets
 if build_type == 'release'
@@ -78,6 +85,17 @@ if enable_pqc
    ),
    language: 'c'
 )
+endif
+
+if enable_tpm2_backend
+   add_project_arguments(
+      c_compiler.get_supported_arguments(
+         '-DENABLE_TPM2_BACKEND',
+         '-DTCTI_MODULE="'+tcti_module+'"',
+         '-DTCTI_CONF="'+tcti_conf+'"',
+      ),
+      language: 'c'
+   )
 endif
 
 if enable_test_log
@@ -131,6 +149,14 @@ if enable_pqc
    # and we have to write a meson file for liboqs in order to allow to
    # integrate it into the build system as subproject.
    dep_liboqs = dependency('liboqs', static: true)
+endif
+
+if enable_tpm2_backend
+   dep_esys = dependency('tss2-esys')
+   dep_tctildr = dependency('tss2-tctildr')
+   # The pkg-config module is named tss2-tcti-<module> whereas the runtime TCTI name
+   # passed to Tss2_TctiLdr_Initialize_ex() is the bare <module> (e.g. mssim/device).
+   dep_tcti = dependency('tss2-tcti-'+tcti_module)
 endif
 
 subdir('src') # Compile provider code as static library

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,11 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 option('build', type : 'combo', choices : ['debug', 'release' ], value : 'debug', description : 'Select build type with associated tool configuration')
-option('enable-tpm2-backend', type : 'boolean', value : false, description : 'This switch enables the use of a TPM2 to protect the persisted state')
-option('tcti-module', type : 'combo', choices : ['device', 'mssim'], value : 'device', description : 'Select TCTI module in case TPM2 is enabled')
-option('tcti-conf', type : 'string', value : '', description : 'Optional TCTI connection configuration appended to the selected module (e.g. host=127.0.0.1,port=2321 for tcti-mssim). Empty uses the module default.')
 option('build-dependencies', type : 'boolean', value : true, yield: true, description : 'Select whether to build dependencies locally rather than use system installed libraries.')
 option('disable-deprecated-warnings', type : 'boolean', value : true, description : 'Select whether or not warnings for deprecated functions are displayed.')
 option('enable-post-quantum-crypto', type : 'boolean', value : false, description : 'This switch enables post quantum crypto algorithms.')
 option('enable-test-log', type : 'boolean', value : false, description : 'This switch enables log messages for the provider tests.')
 option('build-examples', type : 'boolean', value : false, description : 'This switch enables the build of examples.')
+
+# Configuration options to enable the use of a TPM 2.0 to protect the persistent state of the SW provider
+option('enable-tpm2-backend', type : 'boolean', value : false, description : 'This switch enables the use of a TPM2 to protect the persisted state')
+option('tcti-module', type : 'combo', choices : ['device', 'mssim'], value : 'device', description : 'Select TCTI module in case TPM2 is enabled')
+option('tcti-conf', type : 'string', value : '', description : 'Optional TCTI connection configuration appended to the selected module (e.g. host=127.0.0.1,port=2321 for tcti-mssim). Empty uses the module default.')
+option('enable-tpm2-monotonic-counter', type : 'boolean', value : true, description : 'This switch enables the use of a TPM2 based monotonic counter to enhance the protection of the persisted state. This option depends on enable-tpm2-backend=true')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,8 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2024 Siemens
+# SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
 #
 # SPDX-License-Identifier: Apache-2.0
 
 option('build', type : 'combo', choices : ['debug', 'release' ], value : 'debug', description : 'Select build type with associated tool configuration')
+option('enable-tpm2-backend', type : 'boolean', value : false, description : 'This switch enables the use of a TPM2 to protect the persisted state')
+option('tcti-module', type : 'combo', choices : ['device', 'mssim'], value : 'device', description : 'Select TCTI module in case TPM2 is enabled')
+option('tcti-conf', type : 'string', value : '', description : 'Optional TCTI connection configuration appended to the selected module (e.g. host=127.0.0.1,port=2321 for tcti-mssim). Empty uses the module default.')
 option('build-dependencies', type : 'boolean', value : true, yield: true, description : 'Select whether to build dependencies locally rather than use system installed libraries.')
 option('disable-deprecated-warnings', type : 'boolean', value : true, description : 'Select whether or not warnings for deprecated functions are displayed.')
 option('enable-post-quantum-crypto', type : 'boolean', value : false, description : 'This switch enables post quantum crypto algorithms.')

--- a/src/gta_sw_provider.c
+++ b/src/gta_sw_provider.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Siemens
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -492,6 +492,9 @@ GTA_DEFINE_FUNCTION(
     p_provider_params->provider_instance_auth_token_info.issuing_token_issued = false;
     p_provider_params->provider_instance_auth_token_info.issuing_token_revoked = false;
     p_provider_params->provider_instance_auth_token_info.physical_presence_token_issued = false;
+    p_provider_params->monotonic_counter.metadata = NULL;
+    p_provider_params->monotonic_counter.metadata_len = 0;
+    p_provider_params->monotonic_counter.value = 0;
 
     /* Create random token issuing token */
     if (1 != RAND_bytes(
@@ -520,10 +523,7 @@ GTA_DEFINE_FUNCTION(
     /* de-serialize the persisted device state */
     if (serialized_file_exists(p_provider_params->p_serializ_path)) {
         DEBUG_PRINT(("Performing DESERIALIZATION.\n"));
-        if (!provider_deserialize(
-                p_provider_params->p_serializ_path,
-                &(p_provider_params->p_devicestate_stack),
-                p_provider_params->h_ctx)) {
+        if (!provider_deserialize(p_provider_params->p_serializ_path, p_provider_params)) {
             DEBUG_PRINT(("Error while DESERIALIZATION. Cleaning up.\n"));
             devicestate_stack_list_destroy(h_ctx, p_provider_params->p_devicestate_stack, p_errinfo);
             /* Fail when Deserialization error. In order to start just remove existing serialization files */
@@ -545,6 +545,12 @@ GTA_DEFINE_FUNCTION(
         p_provider_params->p_devicestate_stack->owner_lock_count = 0;
         p_provider_params->p_devicestate_stack->p_identifier_list = NULL;
         p_provider_params->p_devicestate_stack->p_personality_name_list = NULL;
+
+        /* Initialize serialization */
+        if (!provider_serialize_init(p_provider_params->p_serializ_path, p_provider_params)) {
+            *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
+            goto err;
+        }
     }
 
     return &g_my_function_list;
@@ -1374,7 +1380,7 @@ GTA_DEFINE_FUNCTION(
     p_provider_params->p_devicestate_stack->owner_lock_count = (uint8_t)owner_lock_count;
 
     /* Serialize */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         goto err;
     }
     return true;
@@ -1467,7 +1473,7 @@ GTA_DEFINE_FUNCTION(
     }
 
     /* Serialize */
-    b_ret = provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack);
+    b_ret = provider_serialize(p_provider_params->p_serializ_path, p_provider_params);
 
     return b_ret;
 }
@@ -1536,7 +1542,7 @@ GTA_DEFINE_FUNCTION(
                     p_identifier_list_item);
                 p_provider_params->p_devicestate_stack->p_identifier_list = p_identifier_list_item;
 
-                ret = provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack);
+                ret = provider_serialize(p_provider_params->p_serializ_path, p_provider_params);
                 if (false == ret) {
                     *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
                     identifier_list_item_free(p_provider_params->h_ctx, p_identifier_list_item, &errinfo_tmp);
@@ -2200,7 +2206,7 @@ static bool personality_deploy_create(
         (struct list_t **)(&(p_provider_params->p_devicestate_stack->p_personality_name_list)),
         p_personality_name_list_item);
 
-    if (provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         return true;
     }
 
@@ -2385,7 +2391,7 @@ GTA_DEFINE_FUNCTION(
     }
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }
@@ -2429,7 +2435,7 @@ GTA_DEFINE_FUNCTION(
     p_context_params->p_personality_item->activated = false;
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }
@@ -2485,7 +2491,7 @@ GTA_DEFINE_FUNCTION(
     p_context_params->p_personality_item->activated = true;
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }
@@ -2558,7 +2564,7 @@ bool personality_add_attribute(
             p_errinfo)) {
 
         /* Serialize the new device state */
-        if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+        if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
             *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
             goto err;
         }
@@ -2788,7 +2794,7 @@ GTA_DEFINE_FUNCTION(
     personality_attribute_list_item_free(p_provider_params->h_ctx, p_attribute, &errinfo_tmp);
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }
@@ -2838,7 +2844,7 @@ GTA_DEFINE_FUNCTION(
     p_attribute->activated = false;
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }
@@ -2900,7 +2906,7 @@ GTA_DEFINE_FUNCTION(
     p_attribute->activated = true;
 
     /* Serialize the new device state */
-    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params->p_devicestate_stack)) {
+    if (!provider_serialize(p_provider_params->p_serializ_path, p_provider_params)) {
         *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
         goto err;
     }

--- a/src/gta_sw_provider.h
+++ b/src/gta_sw_provider.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2025 Siemens
+ * SPDX-FileCopyrightText: Copyright 2025-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -104,6 +104,13 @@ struct gta_sw_provider_params_t {
 
     /* Path used for Serialization files */
     char p_serializ_path[SERIALIZE_PATH_LEN_MAX + 2];
+
+    /* Monotonic counter related variables */
+    struct monotonic_counter_t {
+        uint64_t value;
+        unsigned char * metadata;
+        size_t metadata_len;
+    } monotonic_counter;
 };
 
 /* provider local context specific data */

--- a/src/key_management.c
+++ b/src/key_management.c
@@ -294,3 +294,344 @@ err:
     return b_ret;
 }
 #endif
+
+/*
+ * The following three functions can be implemented to add support
+ * for a monotonic counter to enhance the protection of the information
+ * objects of the gta_sw_provider at rest.
+ */
+
+/*
+ * This function initializes a monotonic counter. The function
+ * can optionally use the parameters `metadata` and `metadata_len` to
+ * store context information needed for the counter operation. The
+ * memory for `metadata` must be allocated with `gta_secmem_calloc`.
+ *
+ * The function should return:
+ *   true, in case the initialization was successful.
+ *   false, on failure
+ */
+#ifndef ENABLE_TPM2_MONOTONIC_COUNTER
+bool init_monotonic_counter(gta_context_handle_t h_ctx, unsigned char ** metadata, size_t * metadata_len)
+{
+    (void)h_ctx;
+    *metadata = NULL;
+    *metadata_len = 0;
+
+    return true;
+}
+
+#else
+
+bool init_monotonic_counter(gta_context_handle_t h_ctx, unsigned char ** metadata, size_t * metadata_len)
+{
+    bool ret = false;
+    ESYS_CONTEXT * p_esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT * p_tcti_ctx = NULL;
+
+    TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+
+    /* The NV index is accessed exclusively through the owner hierarchy
+       (TPMA_NV_OWNERWRITE / TPMA_NV_OWNERREAD), so no index-specific
+       authorization value is required and an empty auth is used. */
+    TPM2B_AUTH auth = {.size = 0, .buffer = {0}};
+
+    /* The NV index is a hardware monotonic counter (TPM2_NT_COUNTER) accessed via the owner
+       hierarchy. Its value is not secret (it is stored in cleartext inside the COSE-signed
+       provider state and only compared for freshness), so no read/write auth value and no
+       write-lock (TPMA_NV_WRITE_STCLEAR) are needed. The monotonicity guarantee that the
+       anti-rollback scheme relies on is provided by TPM2_NT_COUNTER itself. */
+    TPM2B_NV_PUBLIC publicInfo = {
+        .size = 0,
+        .nvPublic = {
+            .nvIndex = TPM2_NV_INDEX_FIRST, /* here the nv-index chosen is set
+                                               TPM2_NV_INDEX_FIRST is 0x1000000
+                                               to ensure that the chosen is not already
+                                               assigned by the tpm perhaps a code like in handle_no_index_specified()
+                                               in tpm2_nvdefine.c of tpm tools could be used? */
+            .nameAlg = TPM2_ALG_SHA256,
+            .attributes = (TPMA_NV_OWNERWRITE | TPMA_NV_OWNERREAD | TPM2_NT_COUNTER << TPMA_NV_TPM2_NT_SHIFT),
+            .authPolicy =
+                {
+                    .size = 0,
+                    .buffer = {0},
+                },
+            .dataSize = 8,
+        }};
+
+    uint8_t * buffer = NULL;
+    size_t buffer_size = 0;
+
+    /************/
+    /* tpm_open */
+    r = Tss2_TctiLdr_Initialize_Ex(TCTI_MODULE, TCTI_CONF_OR_NULL, &p_tcti_ctx);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Tss2_TctiLdr_Initialize_Ex failed\n");
+        goto error;
+    }
+
+    r = Esys_Initialize(&p_esys_ctx, p_tcti_ctx, NULL);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_Initialize failed\n");
+        goto error;
+    }
+
+    /*
+     * Define the NV counter index. This only needs to happen once (the first time the
+     * gta api is used on this device). On subsequent runs the index already exists, in
+     * which case TPM2_RC_NV_DEFINED is returned and we simply obtain a handle to the
+     * existing index instead of defining and initializing it again.
+     */
+    r = Esys_NV_DefineSpace(
+        p_esys_ctx,
+        ESYS_TR_RH_OWNER,
+        ESYS_TR_PASSWORD, /* password for the owner hierarchy */
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &auth, /* autorization value for the created nv index */
+        &publicInfo,
+        &nvHandle);
+
+    if (TPM2_RC_NV_DEFINED == r) {
+        /* Index already exists from a previous run: get its ESYS_TR handle. */
+        r = Esys_TR_FromTPMPublic(
+            p_esys_ctx, publicInfo.nvPublic.nvIndex, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, &nvHandle);
+
+        if (TSS2_RC_SUCCESS != r) {
+            DEBUG_PRINT("Esys_TR_FromTPMPublic failed\n");
+            goto error;
+        }
+    } else if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_NV_DefineSpace failed\n");
+        goto error;
+    } else {
+        /* A freshly defined counter index must be initialized with a single
+           NV_Increment before it can be read. */
+        r = Esys_NV_Increment(p_esys_ctx, ESYS_TR_RH_OWNER, nvHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
+
+        if (TSS2_RC_SUCCESS != r) {
+            DEBUG_PRINT("Esys_NV_Increment failed\n");
+            goto error;
+        }
+    }
+
+    r = Esys_TR_Serialize(p_esys_ctx, nvHandle, &buffer, &buffer_size);
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_TR_Serialize failed\n");
+        goto error;
+    }
+
+    /* Allocate Memory for buffer ... */
+    gta_errinfo_t errinfo = GTA_ERROR_INTERNAL_ERROR;
+    *metadata = gta_secmem_calloc(h_ctx, 1, buffer_size, &errinfo);
+    if (NULL == *metadata) {
+        DEBUG_PRINT("gta_secmem_calloc failed\n");
+        goto error;
+    }
+
+    memcpy(*metadata, buffer, buffer_size);
+    *metadata_len = buffer_size;
+
+    ret = true;
+
+error:
+
+    if (buffer) {
+        Esys_Free(buffer);
+    }
+
+    /*************/
+    /* tpm_close */
+
+    /* Remove the TSS context */
+    if (NULL != p_esys_ctx) {
+        Esys_Finalize(&p_esys_ctx);
+    }
+
+    /* Remove the TSS context */
+    if (NULL != p_tcti_ctx) {
+        Tss2_TctiLdr_Finalize(&p_tcti_ctx);
+    }
+
+    return ret;
+}
+#endif
+
+/*
+ * This function reads the current value of the monotonic counter and
+ * returns it to the gta_sw_provider. The function gets access to the
+ * metadata, which is optionally initialized during
+ * `init_monotonic_counter`.
+ *
+ * The function should return:
+ *   true, in case the current counter value was written to counter_value.
+ *   false, on failure
+ */
+#ifndef ENABLE_TPM2_MONOTONIC_COUNTER
+bool read_monotonic_counter(unsigned char * metadata, size_t metadata_len, uint64_t * counter_value)
+{
+    (void)metadata;
+    (void)metadata_len;
+    *counter_value = 0;
+
+    return true;
+}
+
+#else
+
+bool read_monotonic_counter(unsigned char * metadata, size_t metadata_len, uint64_t * counter_value)
+{
+    bool ret = false;
+    ESYS_CONTEXT * p_esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT * p_tcti_ctx = NULL;
+
+    TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+
+    TPM2B_MAX_NV_BUFFER * nv_test_data = NULL;
+
+    /************/
+    /* tpm_open */
+
+    r = Tss2_TctiLdr_Initialize_Ex(TCTI_MODULE, TCTI_CONF_OR_NULL, &p_tcti_ctx);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Tss2_TctiLdr_Initialize_Ex failed\n");
+        goto error;
+    }
+
+    r = Esys_Initialize(&p_esys_ctx, p_tcti_ctx, NULL);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_Initialize failed\n");
+        goto error;
+    }
+
+    r = Esys_TR_Deserialize(p_esys_ctx, metadata, metadata_len, &nvHandle);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_TR_Deserialize failed\n");
+        goto error;
+    }
+
+    r = Esys_NV_Read(
+        p_esys_ctx, ESYS_TR_RH_OWNER, nvHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, 8, 0, &nv_test_data);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_NV_Read failed\n");
+        goto error;
+    }
+
+    /* NV counter data is returned big-endian (most significant byte first) */
+    for (int i = 0; i < 8; ++i) {
+        *counter_value <<= 8;
+        *counter_value |= nv_test_data->buffer[i];
+    }
+
+    ret = true;
+
+error:
+
+    if (nv_test_data) {
+        Esys_Free(nv_test_data);
+    }
+
+    /*************/
+    /* tpm_close */
+
+    /* Remove the TSS context */
+    if (NULL != p_esys_ctx) {
+        Esys_Finalize(&p_esys_ctx);
+    }
+
+    /* Remove the TSS context */
+    if (NULL != p_tcti_ctx) {
+        Tss2_TctiLdr_Finalize(&p_tcti_ctx);
+    }
+
+    return ret;
+}
+#endif
+
+/*
+ * This function increments the monotonic counter. The function gets access to the
+ * metadata, which is optionally initialized during `init_monotonic_counter`.
+ *
+ * The function should return:
+ *   true, in case the counter was successfully incremented.
+ *   false, on failure
+ */
+#ifndef ENABLE_TPM2_MONOTONIC_COUNTER
+bool increment_monotonic_counter(unsigned char * metadata, size_t metadata_len)
+{
+    (void)metadata;
+    (void)metadata_len;
+
+    return true;
+}
+
+#else
+
+bool increment_monotonic_counter(unsigned char * metadata, size_t metadata_len)
+{
+    bool ret = false;
+    ESYS_CONTEXT * p_esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT * p_tcti_ctx = NULL;
+
+    TSS2_RC r;
+    ESYS_TR nvHandle = ESYS_TR_NONE;
+
+    /************/
+    /* tpm_open */
+
+    r = Tss2_TctiLdr_Initialize_Ex(TCTI_MODULE, TCTI_CONF_OR_NULL, &p_tcti_ctx);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Tss2_TctiLdr_Initialize_Ex failed\n");
+        goto error;
+    }
+
+    r = Esys_Initialize(&p_esys_ctx, p_tcti_ctx, NULL);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_Initialize failed\n");
+        goto error;
+    }
+
+    r = Esys_TR_Deserialize(p_esys_ctx, metadata, metadata_len, &nvHandle);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_TR_Deserialize failed\n");
+        goto error;
+    }
+
+    r = Esys_NV_Increment(p_esys_ctx, ESYS_TR_RH_OWNER, nvHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE);
+
+    if (TSS2_RC_SUCCESS != r) {
+        DEBUG_PRINT("Esys_NV_Increment failed\n");
+        goto error;
+    }
+
+    ret = true;
+
+error:
+
+    /*************/
+    /* tpm_close */
+
+    /* Remove the TSS context */
+    if (NULL != p_esys_ctx) {
+        Esys_Finalize(&p_esys_ctx);
+    }
+
+    /* Remove the TSS context */
+    if (NULL != p_tcti_ctx) {
+        Tss2_TctiLdr_Finalize(&p_tcti_ctx);
+    }
+
+    return ret;
+}
+#endif

--- a/src/key_management.c
+++ b/src/key_management.c
@@ -1,12 +1,26 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024 Siemens
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "key_management.h"
 
+#include "gta_debug.h"
 #include <string.h>
+
+#ifdef ENABLE_TPM2_BACKEND
+#include <stdlib.h>
+#include <tss2/tss2_esys.h>
+#include <tss2/tss2_tctildr.h>
+
+/* Derivation value used to derive the hardware unique key (HUK) from the TPM primary key */
+#define HUK_DERIVATION_VALUE "gta-api-sw-provider-tpm-huk"
+
+/* TCTI_CONF is compiled from the (optional) tcti-conf Meson option. An empty string
+   means "use the module default", which Tss2_TctiLdr_Initialize_Ex() expects as NULL. */
+#define TCTI_CONF_OR_NULL (TCTI_CONF[0] != '\0' ? TCTI_CONF : NULL)
+#endif
 
 /*
  * This function can be implemented to provide a 32 byte hardware
@@ -19,6 +33,7 @@
  *   true, in case 32 byte hardware unique key are written to key->data
  *   false, on failure
  */
+#ifndef ENABLE_TPM2_BACKEND
 bool get_hw_unique_key_32(struct hw_unique_key_32 * key)
 {
     static const unsigned char hardcoded_key[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x01, 0x02, 0x03,
@@ -33,3 +48,249 @@ bool get_hw_unique_key_32(struct hw_unique_key_32 * key)
 
     return true;
 }
+
+#else
+
+bool get_hw_unique_key_32(struct hw_unique_key_32 * key)
+{
+
+    bool b_ret = false;
+    TSS2_RC tss2_ret = TSS2_TCTI_RC_GENERAL_FAILURE;
+    ESYS_CONTEXT * p_esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT * p_tcti_ctx = NULL;
+    ESYS_TR h_session = ESYS_TR_NONE;
+    ESYS_TR h_salt_key = ESYS_TR_NONE;
+    ESYS_TR h_primary_key = ESYS_TR_NONE;
+    TPM2B_DIGEST * p_out_hmac = NULL;
+
+    if (NULL == key) {
+        goto err;
+    }
+
+    tss2_ret = Tss2_TctiLdr_Initialize_Ex(TCTI_MODULE, TCTI_CONF_OR_NULL, &p_tcti_ctx);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Tss2_TctiLdr_Initialize_Ex failed\n");
+        goto err;
+    }
+
+    tss2_ret = Esys_Initialize(&p_esys_ctx, p_tcti_ctx, NULL);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_Initialize failed\n");
+        goto err;
+    }
+
+    /* Starting HMAC session */
+    const TPMT_SYM_DEF symmetric = {.algorithm = TPM2_ALG_AES, .keyBits = {.aes = 128}, .mode = {.aes = TPM2_ALG_CFB}};
+
+    /*
+     * Create a restricted ECC decryption key to salt the HMAC session. Salting gives the
+     * session a non-empty key, which is required for TPMA_SESSION_ENCRYPT/DECRYPT to actually
+     * protect the derivation value and the returned HUK on the TPM bus.
+     *
+     * NOTE: The salt key's public part is created and returned by the TPM over the same bus,
+     * so this defends against passive bus snooping but not against an active interposer that
+     * substitutes its own key.
+     */
+    TPM2B_SENSITIVE_CREATE salt_sensitive = {.size = 0, .sensitive = {.userAuth = {.size = 0}, .data = {.size = 0}}};
+    TPM2B_DATA salt_outside_info = {.size = 0};
+    TPML_PCR_SELECTION salt_pcr = {.count = 0};
+
+    TPM2B_PUBLIC salt_public = {
+        .size = 0,
+        .publicArea = {
+            .type = TPM2_ALG_ECC,
+            .nameAlg = TPM2_ALG_SHA256,
+            .objectAttributes =
+                (TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT | TPMA_OBJECT_SENSITIVEDATAORIGIN |
+                 TPMA_OBJECT_USERWITHAUTH | TPMA_OBJECT_RESTRICTED | TPMA_OBJECT_DECRYPT),
+            .authPolicy = {.size = 0},
+            .parameters.eccDetail =
+                {
+                    .symmetric = {.algorithm = TPM2_ALG_AES, .keyBits.aes = 128, .mode.aes = TPM2_ALG_CFB},
+                    .scheme = {.scheme = TPM2_ALG_NULL},
+                    .curveID = TPM2_ECC_NIST_P256,
+                    .kdf = {.scheme = TPM2_ALG_NULL},
+                },
+            .unique.ecc = {.x = {.size = 0}, .y = {.size = 0}},
+        }};
+
+    tss2_ret = Esys_CreatePrimary(
+        p_esys_ctx,
+        ESYS_TR_RH_ENDORSEMENT,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &salt_sensitive,
+        &salt_public,
+        &salt_outside_info,
+        &salt_pcr,
+        &h_salt_key,
+        NULL,
+        NULL,
+        NULL,
+        NULL);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_CreatePrimary (salt key) failed\n");
+        goto err;
+    }
+
+    tss2_ret = Esys_StartAuthSession(
+        p_esys_ctx,
+        h_salt_key,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        NULL,
+        TPM2_SE_HMAC,
+        &symmetric,
+        TPM2_ALG_SHA256,
+        &h_session);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_StartAuthSession failed\n");
+        goto err;
+    }
+
+    /*********************************/
+    /* create primary and derive key */
+
+    TPM2B_AUTH auth_value_primary = {.size = 0, .buffer = {0}};
+
+    TPM2B_SENSITIVE_CREATE in_sensitive_primary = {
+        .size = 0,
+        .sensitive =
+            {
+                .userAuth =
+                    {
+                        .size = 0,
+                        .buffer = {0},
+                    },
+                .data =
+                    {
+                        .size = 0,
+                        .buffer = {0},
+                    },
+            },
+    };
+    in_sensitive_primary.sensitive.userAuth = auth_value_primary;
+    TPM2B_PUBLIC in_public = {0};
+
+    TPM2B_DATA outside_info = {
+        .size = 0,
+        .buffer = {0},
+    };
+    TPML_PCR_SELECTION creation_pcr = {
+        .count = 0,
+    };
+
+    in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
+    in_public.publicArea.type = TPM2_ALG_KEYEDHASH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SIGN_ENCRYPT;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_USERWITHAUTH;
+    in_public.publicArea.objectAttributes |= TPMA_OBJECT_SENSITIVEDATAORIGIN;
+    in_public.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM2_ALG_HMAC;
+    in_public.publicArea.parameters.keyedHashDetail.scheme.details.hmac.hashAlg = TPM2_ALG_SHA256;
+
+    tss2_ret = Esys_CreatePrimary(
+        p_esys_ctx,
+        ESYS_TR_RH_ENDORSEMENT,
+        ESYS_TR_PASSWORD,
+        ESYS_TR_NONE,
+        ESYS_TR_NONE,
+        &in_sensitive_primary,
+        &in_public,
+        &outside_info,
+        &creation_pcr,
+        &h_primary_key,
+        NULL,
+        NULL,
+        NULL,
+        NULL);
+
+    if (tss2_ret != TSS2_RC_SUCCESS) {
+        DEBUG_PRINT("Esys_CreatePrimary failed\n");
+        goto err;
+    }
+
+    tss2_ret = Esys_TR_SetAuth(p_esys_ctx, h_primary_key, &auth_value_primary);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_TR_SetAuth failed\n");
+        goto err;
+    }
+
+    TPM2B_MAX_BUFFER dv_buffer = {.size = sizeof(HUK_DERIVATION_VALUE) - 1, .buffer = HUK_DERIVATION_VALUE};
+
+    TPMA_SESSION session_attributes = TPMA_SESSION_ENCRYPT | TPMA_SESSION_DECRYPT;
+
+    tss2_ret = Esys_TRSess_SetAttributes(p_esys_ctx, h_session, session_attributes, 0xff);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_TRSess_SetAttributes failed\n");
+        goto err;
+    }
+
+    tss2_ret = Esys_HMAC(
+        p_esys_ctx, h_primary_key, ESYS_TR_PASSWORD, h_session, ESYS_TR_NONE, &dv_buffer, TPM2_ALG_SHA256, &p_out_hmac);
+
+    if (TSS2_RC_SUCCESS != tss2_ret) {
+        DEBUG_PRINT("Esys_HMAC failed\n");
+        goto err;
+    }
+
+    if (HUK_SIZE_32 > p_out_hmac->size) {
+        DEBUG_PRINT("HUK_SIZE_32 > p_out_hmac->size\n");
+        goto err;
+    }
+
+    /*********************************************************************/
+    /* Copy 32 bytes of derived key to hardware unique key output buffer */
+
+    memcpy(key->data, p_out_hmac->buffer, HUK_SIZE_32);
+
+    b_ret = true;
+
+err:
+
+    /***********************/
+    /* clean up everything */
+
+    if (NULL != p_out_hmac) {
+        free(p_out_hmac);
+    }
+
+    /* Flush endorsement key */
+    if (ESYS_TR_NONE != h_primary_key) {
+        (void)Esys_FlushContext(p_esys_ctx, h_primary_key);
+    }
+
+    /* Flush salt key */
+    if (ESYS_TR_NONE != h_salt_key) {
+        (void)Esys_FlushContext(p_esys_ctx, h_salt_key);
+    }
+
+    /*************/
+    /* tpm_close */
+
+    /* Close open HMAC-Session */
+    if (ESYS_TR_NONE != h_session) {
+        Esys_FlushContext(p_esys_ctx, h_session);
+    }
+
+    /* Remove the TSS context */
+    if (NULL != p_esys_ctx) {
+        Esys_Finalize(&p_esys_ctx);
+    }
+
+    /* Remove the TSS context */
+    if (NULL != p_tcti_ctx) {
+        Tss2_TctiLdr_Finalize(&p_tcti_ctx);
+    }
+
+    return b_ret;
+}
+#endif

--- a/src/key_management.h
+++ b/src/key_management.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024 Siemens
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 #ifndef KEY_MANAGEMENT_H
 #define KEY_MANAGEMENT_H
 
+#include <gta_api/gta_api.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -17,5 +18,9 @@ struct hw_unique_key_32 {
 };
 
 bool get_hw_unique_key_32(struct hw_unique_key_32 * key);
+
+bool init_monotonic_counter(gta_context_handle_t h_ctx, unsigned char ** metadata, size_t * metadata_len);
+bool read_monotonic_counter(unsigned char * metadata, size_t metadata_len, uint64_t * counter_value);
+bool increment_monotonic_counter(unsigned char * metadata, size_t metadata_len);
 
 #endif /* KEY_MANAGEMENT_H */

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024-2025 Siemens
+# SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -31,11 +31,19 @@ if enable_pqc
                  ]
 endif
 
+if enable_tpm2_backend
+    build_dep += [ dep_esys,
+                   dep_tctildr,
+                   dep_tcti,
+                 ]
+endif
+
 gta_sw_provider_static = static_library('gta_sw_provider',
     gta_sw_provider_files,
     dependencies : build_dep,
           c_args : ['-DNDEBUG',
                    ],
+
     install: true
 )
 

--- a/src/persistent_storage.c
+++ b/src/persistent_storage.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024-2025 Siemens
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,6 +29,10 @@
 /* File names for serialization */
 #define FILE_PERSONALITY "PERS_"
 #define FILE_DEVICESTATES_STACK "DEVICESTATES_STACK"
+
+/* Labels used in CBOR Map - Monotonic Counter */
+#define LABEL_MC_VALUE "MonotonicCounterValue"
+#define LABEL_MC_METADATA "MonotonicCounterMetadata"
 
 /* Labels used in CBOR Map - Device State */
 #define LABEL_AUTH_RECEDE_LIST "AuthRecedeList"
@@ -328,9 +332,60 @@ err:
     return ret;
 }
 
-bool provider_serialize(const char * se_dir, struct devicestate_stack_item_t * p_devicestate_stack)
+/*
+ * Helper function for provider_serialize() and provider_serialize_init() to
+ * sign the overall serialized state and write it to the file system.
+ */
+static bool cose_sign_and_write(const char * se_dir, UsefulBufC encoded_data)
+{
+    /* Encode COSE Protection */
+    Q_USEFUL_BUF_MAKE_STACK_UB(signed_cose_buffer, COSE_DATA_LEN);
+    struct q_useful_buf_c signed_cose;
+    enum t_cose_err_t t_cose_result;
+    struct t_cose_mac_calculate_ctx mac_ctx;
+    struct t_cose_key key;
+    unsigned char raw_key[HMAC_256_KEY_LEN];
+    bool ret = false;
+
+    t_cose_mac_compute_init(&mac_ctx, 0, T_COSE_ALGORITHM_HMAC256);
+
+    /* get & set the COSE Key */
+    get_derived_key(raw_key, HMAC_256_KEY_LEN, INFO_KEY_MAC, sizeof(INFO_KEY_MAC) - 1);
+    t_cose_key_init_symmetric(T_COSE_ALGORITHM_HMAC256, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(raw_key), &key);
+    t_cose_mac_set_computing_key(&mac_ctx, key, NULL_Q_USEFUL_BUF_C);
+
+    t_cose_result = t_cose_mac_compute(&mac_ctx, NULL_Q_USEFUL_BUF_C, encoded_data, signed_cose_buffer, &signed_cose);
+
+    /* TODO clean Keys */
+
+    if (T_COSE_SUCCESS != t_cose_result) {
+        goto err;
+    }
+
+    /* File Name */
+    char filename[FILENAME_MAX] = {0};
+    if (!get_se_filename(SE_FILE_DEVICESTATES_STACK, "", se_dir, filename)) {
+        goto err;
+    }
+
+    /* File IO */
+    FILE * fp = NULL;
+    if (NULL == (fp = fopen(filename, "wb"))) {
+        goto err;
+    }
+    fwrite(signed_cose.ptr, signed_cose.len, 1, fp);
+    fclose(fp);
+
+    ret = true;
+
+err:
+    return ret;
+}
+
+bool provider_serialize(const char * se_dir, struct gta_sw_provider_params_t * provider_params)
 {
     bool ret = false;
+    struct devicestate_stack_item_t * p_devicestate_stack = provider_params->p_devicestate_stack;
     struct devicestate_stack_item_t * p_devicestate_stack_item;
 
     /* CBOR related stuff */
@@ -340,14 +395,36 @@ bool provider_serialize(const char * se_dir, struct devicestate_stack_item_t * p
     UsefulBufC encoded_data;
     QCBORError qcbor_result;
 
-    /* COSE related stuff */
-    Q_USEFUL_BUF_MAKE_STACK_UB(signed_cose_buffer, COSE_DATA_LEN);
-    struct q_useful_buf_c signed_cose;
-    enum t_cose_err_t t_cose_result;
+    /* Increment monotonic counter */
+    uint64_t counter_value = 0;
+    if (!increment_monotonic_counter(
+            provider_params->monotonic_counter.metadata, provider_params->monotonic_counter.metadata_len)) {
+        goto err;
+    }
+
+    /* Read monotonic counter value */
+    if (!read_monotonic_counter(
+            provider_params->monotonic_counter.metadata,
+            provider_params->monotonic_counter.metadata_len,
+            &counter_value)) {
+        goto err;
+    }
+
+    /* Write new value to datamodel */
+    provider_params->monotonic_counter.value = counter_value;
 
     QCBOREncode_Init(&encode_ctx, encode_buffer);
 
-    /* TODO review all String Zero terminated assumed below */
+    /* Assume all Strings below are Zero terminated */
+
+    /* Map for Monotonic Counter */
+    QCBOREncode_OpenMap(&encode_ctx);
+    QCBOREncode_AddUInt64ToMap(&encode_ctx, LABEL_MC_VALUE, counter_value);
+    UsefulBufC mc_metadata;
+    mc_metadata.ptr = provider_params->monotonic_counter.metadata;
+    mc_metadata.len = provider_params->monotonic_counter.metadata_len;
+    QCBOREncode_AddBytesToMap(&encode_ctx, LABEL_MC_METADATA, mc_metadata);
+    QCBOREncode_CloseMap(&encode_ctx);
 
     /* Array of all Device States */
     QCBOREncode_OpenArray(&encode_ctx);
@@ -426,38 +503,91 @@ bool provider_serialize(const char * se_dir, struct devicestate_stack_item_t * p
     }
 
     /* Encode COSE Protection */
-    struct t_cose_mac_calculate_ctx mac_ctx;
-    struct t_cose_key key;
-    unsigned char raw_key[HMAC_256_KEY_LEN];
-
-    t_cose_mac_compute_init(&mac_ctx, 0, T_COSE_ALGORITHM_HMAC256);
-
-    /* get & set the COSE Key */
-    get_derived_key(raw_key, HMAC_256_KEY_LEN, INFO_KEY_MAC, sizeof(INFO_KEY_MAC) - 1);
-    t_cose_key_init_symmetric(T_COSE_ALGORITHM_HMAC256, Q_USEFUL_BUF_FROM_BYTE_ARRAY_LITERAL(raw_key), &key);
-    t_cose_mac_set_computing_key(&mac_ctx, key, NULL_Q_USEFUL_BUF_C);
-
-    t_cose_result = t_cose_mac_compute(&mac_ctx, NULL_Q_USEFUL_BUF_C, encoded_data, signed_cose_buffer, &signed_cose);
-
-    /* TODO clean Keys */
-
-    if (T_COSE_SUCCESS != t_cose_result) {
+    if (!cose_sign_and_write(se_dir, encoded_data)) {
         goto err;
     }
 
-    /* File Name */
-    char filename[FILENAME_MAX] = {0};
-    if (!get_se_filename(SE_FILE_DEVICESTATES_STACK, "", se_dir, filename)) {
+    ret = true;
+
+err:
+    return ret;
+}
+
+bool provider_serialize_init(const char * se_dir, struct gta_sw_provider_params_t * provider_params)
+{
+    bool ret = false;
+    const struct devicestate_stack_item_t * p_devicestate_stack_item = provider_params->p_devicestate_stack;
+
+    /* CBOR related stuff */
+    QCBOREncodeContext encode_ctx;
+    UsefulBuf_MAKE_STACK_UB(encode_buffer, ENCODED_DATA_LEN);
+    UsefulBufC encoded_data;
+    QCBORError qcbor_result;
+
+    /* Initialize monotonic counter */
+    if (!init_monotonic_counter(
+            provider_params->h_ctx,
+            &provider_params->monotonic_counter.metadata,
+            &provider_params->monotonic_counter.metadata_len)) {
         goto err;
     }
 
-    /* File IO */
-    FILE * fp = NULL;
-    if (NULL == (fp = fopen(filename, "wb"))) {
+    /* Read monotonic counter value */
+    if (!read_monotonic_counter(
+            provider_params->monotonic_counter.metadata,
+            provider_params->monotonic_counter.metadata_len,
+            &provider_params->monotonic_counter.value)) {
         goto err;
     }
-    fwrite(signed_cose.ptr, signed_cose.len, 1, fp);
-    fclose(fp);
+
+    QCBOREncode_Init(&encode_ctx, encode_buffer);
+
+    /* TODO review all String Zero terminated assumed below */
+
+    /* Map for Monotonic Counter */
+    QCBOREncode_OpenMap(&encode_ctx);
+    QCBOREncode_AddUInt64ToMap(&encode_ctx, LABEL_MC_VALUE, provider_params->monotonic_counter.value);
+    UsefulBufC mc_metadata;
+    mc_metadata.ptr = provider_params->monotonic_counter.metadata;
+    mc_metadata.len = provider_params->monotonic_counter.metadata_len;
+    QCBOREncode_AddBytesToMap(&encode_ctx, LABEL_MC_METADATA, mc_metadata);
+    QCBOREncode_CloseMap(&encode_ctx);
+
+    /* Array of all Device States */
+    QCBOREncode_OpenArray(&encode_ctx);
+
+    /* Map of a Device State */
+    QCBOREncode_OpenMap(&encode_ctx);
+
+    /* Auth recede of the Device State (empty) */
+    QCBOREncode_OpenArrayInMap(&encode_ctx, LABEL_AUTH_RECEDE_LIST);
+    QCBOREncode_CloseArray(&encode_ctx);
+
+    /* Scalars of the Device State */
+    QCBOREncode_AddUInt64ToMap(&encode_ctx, LABEL_DEVICE_STATE_LOCK, p_devicestate_stack_item->owner_lock_count);
+
+    /* Array of Identifiers associated with the Device State (empty) */
+    QCBOREncode_OpenArrayInMap(&encode_ctx, LABEL_IDENTIFIERS);
+    QCBOREncode_CloseArray(&encode_ctx);
+
+    /* Array of Personalities associated with the Device State (empty) */
+    QCBOREncode_OpenArrayInMap(&encode_ctx, LABEL_PERSONALITIES);
+    QCBOREncode_CloseArray(&encode_ctx);
+
+    /* Close map containing a Device State */
+    QCBOREncode_CloseMap(&encode_ctx);
+
+    /* Close array of all Device States */
+    QCBOREncode_CloseArray(&encode_ctx);
+    qcbor_result = QCBOREncode_Finish(&encode_ctx, &encoded_data);
+    if (QCBOR_SUCCESS != qcbor_result) {
+        goto err;
+    }
+
+    /* Encode COSE Protection and write state */
+    if (!cose_sign_and_write(se_dir, encoded_data)) {
+        goto err;
+    }
 
     ret = true;
 
@@ -1081,10 +1211,58 @@ err:
     return ret;
 }
 
-bool provider_deserialize(
-    const char * se_dir,
-    struct devicestate_stack_item_t ** pp_devicestate_stack,
+static bool decode_monotonic_counter(
+    QCBORDecodeContext * p_decode_ctx,
+    struct gta_sw_provider_params_t * provider_params,
     gta_context_handle_t h_ctx)
+{
+    bool ret = false;
+    gta_errinfo_t errinfo = GTA_ERROR_INTERNAL_ERROR;
+
+    /* CBOR related stuff */
+    UsefulBufC tmp_bytes;
+    QCBORItem Item;
+    QCBORError qcbor_result;
+
+    /* Enter map of monotonic counter */
+    QCBORDecode_EnterMap(p_decode_ctx, &Item);
+    qcbor_result = QCBORDecode_GetError(p_decode_ctx);
+
+    if (qcbor_result == QCBOR_ERR_NO_MORE_ITEMS) {
+        goto err;
+    }
+    if (qcbor_result != QCBOR_SUCCESS) {
+        goto err;
+    }
+
+    /* Decode Counter Value */
+    QCBORDecode_GetUInt64InMapSZ(p_decode_ctx, LABEL_MC_VALUE, &provider_params->monotonic_counter.value);
+
+    /* Decode Counter Metadata */
+    QCBORDecode_GetByteStringInMapSZ(p_decode_ctx, LABEL_MC_METADATA, &tmp_bytes);
+    provider_params->monotonic_counter.metadata = gta_secmem_calloc(h_ctx, 1, tmp_bytes.len, &errinfo);
+    if (NULL == provider_params->monotonic_counter.metadata) {
+        goto err;
+    }
+    memcpy(provider_params->monotonic_counter.metadata, tmp_bytes.ptr, tmp_bytes.len);
+    provider_params->monotonic_counter.metadata_len = tmp_bytes.len;
+
+    /* Close map containing Monotonic Counter */
+    QCBORDecode_ExitMap(p_decode_ctx);
+
+    qcbor_result = QCBORDecode_GetError(p_decode_ctx);
+    if (QCBOR_SUCCESS != qcbor_result) {
+        DEBUG_PRINT(("DESERIALIZATION Failed. QCBOR error: %d\n", qcbor_result));
+        goto err;
+    }
+
+    ret = true;
+
+err:
+    return ret;
+}
+
+bool provider_deserialize(const char * se_dir, struct gta_sw_provider_params_t * provider_params)
 {
     bool ret = false;
     gta_errinfo_t errinfo;
@@ -1104,7 +1282,7 @@ bool provider_deserialize(
             fseek(fp, 0L, SEEK_END);
             size_t file_size = ftell(fp);
             rewind(fp);
-            if (NULL != (file_buffer = gta_secmem_calloc(h_ctx, 1, file_size, &errinfo))) {
+            if (NULL != (file_buffer = gta_secmem_calloc(provider_params->h_ctx, 1, file_size, &errinfo))) {
                 file_buffer_size = fread(file_buffer, sizeof(char), file_size, fp);
             }
             fclose(fp);
@@ -1146,22 +1324,43 @@ bool provider_deserialize(
 
         QCBORDecode_Init(&decode_ctx, returned_payload, QCBOR_DECODE_MODE_NORMAL);
 
+        /* Decode Monotonic Counter */
+        if (!decode_monotonic_counter(&decode_ctx, provider_params, provider_params->h_ctx)) {
+            DEBUG_PRINT(("DESERIALIZATION Failed. Error while decoding Monotonic Counter\n"));
+            goto err;
+        }
+
         /* Decode Device States */
         QCBORDecode_EnterArray(&decode_ctx, &Item);
-        if (!decode_devicestates(se_dir, &decode_ctx, pp_devicestate_stack, h_ctx)) {
+        if (!decode_devicestates(se_dir, &decode_ctx, &provider_params->p_devicestate_stack, provider_params->h_ctx)) {
             DEBUG_PRINT(("DESERIALIZATION Failed. Error while decoding Device States\n"));
             goto err;
         }
         QCBORDecode_ExitArray(&decode_ctx);
 
         QCBORDecode_Finish(&decode_ctx);
+
+        /* Read current value of monotonic counter */
+        uint64_t counter_value = 0;
+        if (!read_monotonic_counter(
+                provider_params->monotonic_counter.metadata,
+                provider_params->monotonic_counter.metadata_len,
+                &counter_value)) {
+            goto err;
+        }
+
+        /* Check if counters match */
+        if (provider_params->monotonic_counter.value != counter_value) {
+            DEBUG_PRINT(("Counters do not match: Possible downgrade/replay attack!\n"));
+            goto err;
+        }
     }
 
     ret = true;
 
 err:
     if (NULL != file_buffer) {
-        gta_secmem_free(h_ctx, file_buffer, &errinfo);
+        gta_secmem_free(provider_params->h_ctx, file_buffer, &errinfo);
     }
 
     return ret;

--- a/src/persistent_storage.h
+++ b/src/persistent_storage.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright 2024 Siemens
+ * SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,11 +13,10 @@
 
 bool serialized_file_exists(const char * se_dir);
 
-bool provider_serialize(const char * se_dir, struct devicestate_stack_item_t * p_devicestate_stack);
+bool provider_serialize(const char * se_dir, struct gta_sw_provider_params_t * provider_params);
 
-bool provider_deserialize(
-    const char * se_dir,
-    struct devicestate_stack_item_t ** pp_devicestate_stack,
-    gta_context_handle_t h_ctx);
+bool provider_serialize_init(const char * se_dir, struct gta_sw_provider_params_t * provider_params);
+
+bool provider_deserialize(const char * se_dir, struct gta_sw_provider_params_t * provider_params);
 
 #endif /* PROVIDER_MOCKUP_GTA_PROVIDER_PERSISTENT_STORAGE_NEW_H_ */

--- a/test/main.c
+++ b/test/main.c
@@ -3277,6 +3277,46 @@ static void provider_deserialize(void ** state)
     assert_true(gta_instance_final(h_inst, &errinfo));
 }
 
+/*
+ * This test creates a new instance to test the serialization of a second state.
+ */
+static void provider_serialize(void ** state)
+{
+    DEBUG_PRINT(("gta_sw_provider tests: %s\n", __func__));
+    gta_errinfo_t errinfo = 0;
+    gta_instance_handle_t h_inst = GTA_HANDLE_INVALID;
+
+    /* Clean the state directory */
+    remove_folder_files(DIRECTORY_CLEAN_STATE);
+
+    struct gta_instance_params_t inst_params = {
+        NULL,
+        {
+            .calloc = &calloc,
+            .free = &free,
+            .mutex_create = NULL,
+            .mutex_destroy = NULL,
+            .mutex_lock = NULL,
+            .mutex_unlock = NULL,
+        },
+        NULL};
+    istream_from_buf_t init_config = {0};
+    istream_from_buf_init(&init_config, DIRECTORY_CLEAN_STATE, sizeof(DIRECTORY_CLEAN_STATE) - 1);
+
+    h_inst = gta_instance_init(&inst_params, &errinfo);
+    assert_non_null(h_inst);
+
+    /* register a profile to trigger serialization */
+    assert_true(gta_sw_provider_gta_register_provider(
+        h_inst,
+        (gtaio_istream_t *)&init_config,
+        supported_profiles[PROF_CH_IEC_30168_BASIC_LOCAL_DATA_PROTECTION],
+        &errinfo));
+    assert_int_equal(0, errinfo);
+
+    assert_true(gta_instance_final(h_inst, &errinfo));
+}
+
 /*-----------------------------------------------------------------------------
  * group tests
  */
@@ -3315,6 +3355,7 @@ int ts_gta_sw_provider(void)
         cmocka_unit_test(access_policies_and_access_tokens),
         /* Tests for persistent storage */
         cmocka_unit_test(provider_deserialize),
+        cmocka_unit_test(provider_serialize),
     };
 
     return cmocka_run_group_tests_name(

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024 Siemens
+# SPDX-FileCopyrightText: Copyright 2024-2026 Siemens
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -30,6 +30,7 @@ test_output_dir = 'CMOCKA_XML_FILE=' + meson.current_build_dir() + '/%g.xml'
 test(
     'gta_provider_test',
     gta_provider_test,
+    timeout: 0,
     env: [ test_output_dir,
            'CMOCKA_MESSAGE_OUTPUT=XML',
      ],


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->
This PR implements hooks to operate a monotonic counter to (in addition to the HUK) protect the persistent state against rollback attacks.
In addition, the PR implements all persistent storage hooks for a TPM 2.0, which can be optionally enabled via meson config. 

GitHub Issue Number: #9

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [x] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
